### PR TITLE
Fix CJK subtitle wrapping

### DIFF
--- a/Plugins/CaptionMod/SubtitlePanel.cpp
+++ b/Plugins/CaptionMod/SubtitlePanel.cpp
@@ -440,10 +440,20 @@ std::shared_ptr<CSubLine> SubtitlePanel::AddLine(const std::shared_ptr<CDictiona
 
 static bool IsNonBreakableCharacter(wchar_t ch)
 {
-    if (ch == L'\0') 
-        return false;
+	if (ch == L'\0')
+		return false;
 
-    return (ch != L' ' && ch != L'\t' && ch != L'\r' && ch != L'\n');
+	// CJK body text is normally breakable between characters.
+	if ((ch >= 0x3040 && ch <= 0x30FF) || // Hiragana and Katakana
+		(ch >= 0x3400 && ch <= 0x4DBF) || // CJK Unified Ideographs Extension A
+		(ch >= 0x4E00 && ch <= 0x9FFF) || // CJK Unified Ideographs
+		(ch >= 0xAC00 && ch <= 0xD7AF) || // Hangul Syllables
+		(ch >= 0xF900 && ch <= 0xFAFF))   // CJK Compatibility Ideographs
+	{
+		return false;
+	}
+
+	return (ch != L' ' && ch != L'\t' && ch != L'\r' && ch != L'\n');
 }
 //2015-11-26 added htimescale for SubtitlePanel
 void SubtitlePanel::StartSubtitle(const std::shared_ptr<CDictionary>& dict, float flDurationTime, float flStartTime, const CStartSubtitleContext* pStartSubtitleContext)


### PR DESCRIPTION
## Root cause

CaptionMod's subtitle wrapping treats every non-whitespace character as non-breakable. CJK subtitle text usually has no spaces, so a full Chinese sentence can be measured as one non-breakable run and produce a subtitle line wider than the panel's text area. The panel clips at its bounds, not at the right margin, which makes the text run past the right margin.

## Fix

Allow common CJK body text ranges to break between characters while keeping the existing non-whitespace behavior for non-CJK word-like text.

## Verification

- `git diff --check`

Build/test commands were not run, per the repository instruction not to run tests or builds unless explicitly requested.

Closes #813