### PR TITLE
fix(renderer): correct legacy point light attenuation

### DIFF
--- a/Build/svencoop/renderer/shader/wsurf_shader.frag.glsl
+++ b/Build/svencoop/renderer/shader/wsurf_shader.frag.glsl
@@ -289,6 +289,8 @@ void main()
 #if defined(LEGACY_DLIGHT_ENABLED)
 
 	lightmapColor = R_AddLegacyDynamicLight(lightmapColor);
+	// GoldSrc clamps accumulated blocklights before light gamma conversion.
+	lightmapColor.xyz = clamp(lightmapColor.xyz, 0.0, 1.0);
 
 #endif
 

--- a/Build/svencoop/renderer/shader/wsurf_shader.frag.glsl
+++ b/Build/svencoop/renderer/shader/wsurf_shader.frag.glsl
@@ -89,14 +89,16 @@ vec4 R_AddLegacyDynamicLight(vec4 color)
 		vec3 origin = DLightUBO.origin_radius[i].xyz;
 		float radius = DLightUBO.origin_radius[i].w;
 		vec3 delta = origin - v_worldpos.xyz;
-		float surface_dist = dot(delta, v_normal);
+		vec3 normal = normalize(v_normal);
+		float surface_dist = dot(delta, normal);
 		float effective_radius = radius - abs(surface_dist);
-		float dist = length(delta);
+		vec3 planar_delta = delta - normal * surface_dist;
+		float planar_dist = length(planar_delta);
 
 		vec3 lightcolor = DLightUBO.color_minlight[i].xyz;
 		//float minlight = DLightUBO.color_minlight[i].w; //unused
 		
-		color.xyz += clamp((effective_radius - dist) / 256.0, 0.0, 1.0) * lightcolor.xyz;
+		color.xyz += clamp((effective_radius - planar_dist) / 256.0, 0.0, 1.0) * lightcolor.xyz;
 	}
 
 	return color;


### PR DESCRIPTION
## Summary

- correct legacy point-light attenuation by measuring the remaining radius in surface-planar space
- clamp accumulated legacy lightmap RGB to `[0, 1]` before gamma conversion, matching GoldSrc blocklight behavior

## Root cause

Under `r_gamma_blend 1`, world surfaces use the legacy dynamic-light path.

1. The previous attenuation reduced the radius by the normal distance and then subtracted the full Euclidean distance, counting the normal component twice. This made far-facing walls lose illumination at roughly half the intended radius.
2. After restoring the correct coverage, overlapping night-vision lights could accumulate a lightmap value above `1.0`. Renderer passed that over-range value directly to `ProcessLightmapColor`, so gamma conversion amplified the near wall and washed out its texture. GoldSrc clamps the accumulated blocklight input to `1023` before indexing `lightgammatable`, which is equivalent to clamping the normalized lightmap to `[0, 1]` first.

## Validation

- compiled `wsurf_shader.frag.glsl` for OpenGL with `IS_FRAGMENT_SHADER` and `LEGACY_DLIGHT_ENABLED`
- compiled the affected gamma path with `IS_FRAGMENT_SHADER`, `LEGACY_DLIGHT_ENABLED`, and `GAMMA_BLEND_ENABLED`
- ran `git diff --check`
- verified the clamp with RenderDoc shader replacement against `r_gamma_blend_1_after_pr_835.rdc`: near-wall green changed from `0.5098` to `0.4588`, while the far wall remained illuminated (`0.5529` to `0.5020`)

This should fix #832.