### PR TITLE
fix(renderer): release water models before engine shutdown

### DIFF
--- a/Plugins/Renderer/gl_rmain.cpp
+++ b/Plugins/Renderer/gl_rmain.cpp
@@ -3958,7 +3958,6 @@ void R_NewMap(void)
 	memset(&r_params, 0, sizeof(r_params));
 
 	R_GenerateSceneUBO();
-	R_ClearWaterModelReferences();
 	R_FreeWorldResources();
 	R_FreePortalResouces();
 

--- a/Plugins/Renderer/gl_wsurf.cpp
+++ b/Plugins/Renderer/gl_wsurf.cpp
@@ -3686,6 +3686,9 @@ void R_InitWSurf(void)
 
 void R_FreeWorldResources(void)
 {
+	// Release frame-held water models before their owning leaves on map changes and shutdown.
+	R_ClearWaterModelReferences();
+
 	g_WorldSurfaceRenderer.pCurrentWorldLeaf.reset();
 	g_WorldSurfaceRenderer.pCurrentWaterLeaf.reset();
 	g_WorldSurfaceRenderer.vWorldMaterials.clear();


### PR DESCRIPTION
Fixes #846.

When exiting after rendering water, the global visible-water list retained shared ownership of water models until Renderer.dll's CRT teardown. Their destructors could then call texture/buffer deletion after the engine and OpenGL had shut down.

Move `R_ClearWaterModelReferences()` from `R_NewMap()` into `R_FreeWorldResources()`. Both map changes and renderer shutdown now release visible-water and active/stale entity references before releasing the owning world leaves, so water resources are destroyed during explicit renderer cleanup.

Validation:
- Renderer MSBuild: Release|Win32 and Release_AVX2|Win32 succeeded (existing signedness/unused-variable warnings).
- Isolated C++ lifetime regression harness compiled the actual cleanup functions with stubbed engine/GPU dependencies and the real entity component header. The pre-fix cleanup retained water resources; the fixed cleanup passed map cleanup, shutdown, active/stale references, and repeated cleanup checks.
- `git diff --check` passed; reviewed shutdown ordering and water-model ownership.
- In-game Sven Co-op exit reproduction remains unverified. The isolated harness verifies ownership/destruction timing, not real OpenGL or engine teardown.
