### PR TITLE
feat(MetahookInstaller): add dark mode

### DIFF
--- a/toolsrc/MetahookInstaller/MetahookInstallerAvalonia/App.axaml
+++ b/toolsrc/MetahookInstaller/MetahookInstallerAvalonia/App.axaml
@@ -6,6 +6,96 @@
              x:Class="MetahookInstallerAvalonia.App"
              RequestedThemeVariant="Default">
     <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Light">
+                    <Color x:Key="BackgroundColor">#00000000</Color>
+                    <Color x:Key="BackgroundAcrylicColor">#11F9F9F9</Color>
+                    <Color x:Key="SurfaceColor">#11FFFFFF</Color>
+                    <Color x:Key="SurfaceLightColor">#F5F5F5</Color>
+                    <Color x:Key="SurfaceAcrylicColor">#66FFFFFF</Color>
+                    <Color x:Key="PrimaryColor">#3498DB</Color>
+                    <Color x:Key="PrimaryLightColor">#E6F4FF</Color>
+                    <Color x:Key="TextPrimaryColor">#2C3E50</Color>
+                    <Color x:Key="TextSecondaryColor">#555555</Color>
+                    <Color x:Key="BorderColor">#EEEEEE</Color>
+                    <Color x:Key="BorderLightColor">#DDDDDD</Color>
+                    <Color x:Key="ShadowColor">#15000000</Color>
+                    <Color x:Key="WindowBackgroundColor">#99FFFFFF</Color>
+                    <Color x:Key="TitleBarBackgroundColor">#BBEEEEEE</Color>
+                    <Color x:Key="ContentBackgroundColor">#CCFFFFFF</Color>
+                    <Color x:Key="TitleBarButtonBackgroundColor">#DDDDDDDD</Color>
+                    <Color x:Key="TitleBarButtonHoverColor">#334155</Color>
+                    <Color x:Key="TitleBarForegroundColor">#FF111111</Color>
+                    <!-- 派生资源 -->
+                    <SolidColorBrush x:Key="BackgroundBrush" Color="{DynamicResource BackgroundColor}" />
+                    <SolidColorBrush x:Key="BackgroundAcrylicBrush" Color="{DynamicResource BackgroundAcrylicColor}" />
+                    <SolidColorBrush x:Key="SurfaceBrush" Color="{DynamicResource SurfaceColor}" />
+                    <SolidColorBrush x:Key="SurfaceLightBrush" Color="{DynamicResource SurfaceLightColor}" />
+                    <SolidColorBrush x:Key="SurfaceAcrylicBrush" Color="{DynamicResource SurfaceAcrylicColor}" />
+                    <SolidColorBrush x:Key="PrimaryBrush" Color="{DynamicResource PrimaryColor}" />
+                    <SolidColorBrush x:Key="PrimaryLightBrush" Color="{DynamicResource PrimaryLightColor}" />
+                    <SolidColorBrush x:Key="TextPrimaryBrush" Color="{DynamicResource TextPrimaryColor}" />
+                    <SolidColorBrush x:Key="TextSecondaryBrush" Color="{DynamicResource TextSecondaryColor}" />
+                    <SolidColorBrush x:Key="BorderBrush" Color="{DynamicResource BorderColor}" />
+                    <SolidColorBrush x:Key="BorderLightBrush" Color="{DynamicResource BorderLightColor}" />
+                    <SolidColorBrush x:Key="WindowBackgroundBrush" Color="{DynamicResource WindowBackgroundColor}" />
+                    <SolidColorBrush x:Key="TitleBarBackgroundBrush" Color="{DynamicResource TitleBarBackgroundColor}" />
+                    <SolidColorBrush x:Key="ContentBackgroundBrush" Color="{DynamicResource ContentBackgroundColor}" />
+                    <SolidColorBrush x:Key="TitleBarButtonBackgroundBrush" Color="{DynamicResource TitleBarButtonBackgroundColor}" />
+                    <SolidColorBrush x:Key="TitleBarButtonHoverBrush" Color="{DynamicResource TitleBarButtonHoverColor}" />
+                    <SolidColorBrush x:Key="TitleBarForegroundBrush" Color="{DynamicResource TitleBarForegroundColor}" />
+                    <!-- 阴影资源 -->
+                    <DropShadowEffect x:Key="SmallShadow" BlurRadius="5" Color="{DynamicResource ShadowColor}"/>
+                    <DropShadowEffect x:Key="MediumShadow" BlurRadius="8" Color="{DynamicResource ShadowColor}"/>
+                    <DropShadowEffect x:Key="LargeShadow" BlurRadius="12" Color="{DynamicResource ShadowColor}"/>
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="Dark">
+                    <Color x:Key="BackgroundColor">#00000000</Color>
+                    <Color x:Key="BackgroundAcrylicColor">#11FFFFFF</Color>
+                    <Color x:Key="SurfaceColor">#1FFFFFFF</Color>
+                    <Color x:Key="SurfaceLightColor">#FF333333</Color>
+                    <Color x:Key="SurfaceAcrylicColor">#22FFFFFF</Color>
+                    <Color x:Key="PrimaryColor">#4AA3E8</Color>
+                    <Color x:Key="PrimaryLightColor">#334A90C8</Color>
+                    <Color x:Key="TextPrimaryColor">#FFECECEC</Color>
+                    <Color x:Key="TextSecondaryColor">#FFB0B8C0</Color>
+                    <Color x:Key="BorderColor">#FF3A3A3A</Color>
+                    <Color x:Key="BorderLightColor">#FF4A4A4A</Color>
+                    <Color x:Key="ShadowColor">#40000000</Color>
+                    <Color x:Key="WindowBackgroundColor">#CC1B1B1B</Color>
+                    <Color x:Key="TitleBarBackgroundColor">#BB202020</Color>
+                    <Color x:Key="ContentBackgroundColor">#CC2A2A2A</Color>
+                    <Color x:Key="TitleBarButtonBackgroundColor">#33FFFFFF</Color>
+                    <Color x:Key="TitleBarButtonHoverColor">#4DFFFFFF</Color>
+                    <Color x:Key="TitleBarForegroundColor">#FFECECEC</Color>
+                    <!-- 派生资源 -->
+                    <SolidColorBrush x:Key="BackgroundBrush" Color="{DynamicResource BackgroundColor}" />
+                    <SolidColorBrush x:Key="BackgroundAcrylicBrush" Color="{DynamicResource BackgroundAcrylicColor}" />
+                    <SolidColorBrush x:Key="SurfaceBrush" Color="{DynamicResource SurfaceColor}" />
+                    <SolidColorBrush x:Key="SurfaceLightBrush" Color="{DynamicResource SurfaceLightColor}" />
+                    <SolidColorBrush x:Key="SurfaceAcrylicBrush" Color="{DynamicResource SurfaceAcrylicColor}" />
+                    <SolidColorBrush x:Key="PrimaryBrush" Color="{DynamicResource PrimaryColor}" />
+                    <SolidColorBrush x:Key="PrimaryLightBrush" Color="{DynamicResource PrimaryLightColor}" />
+                    <SolidColorBrush x:Key="TextPrimaryBrush" Color="{DynamicResource TextPrimaryColor}" />
+                    <SolidColorBrush x:Key="TextSecondaryBrush" Color="{DynamicResource TextSecondaryColor}" />
+                    <SolidColorBrush x:Key="BorderBrush" Color="{DynamicResource BorderColor}" />
+                    <SolidColorBrush x:Key="BorderLightBrush" Color="{DynamicResource BorderLightColor}" />
+                    <SolidColorBrush x:Key="WindowBackgroundBrush" Color="{DynamicResource WindowBackgroundColor}" />
+                    <SolidColorBrush x:Key="TitleBarBackgroundBrush" Color="{DynamicResource TitleBarBackgroundColor}" />
+                    <SolidColorBrush x:Key="ContentBackgroundBrush" Color="{DynamicResource ContentBackgroundColor}" />
+                    <SolidColorBrush x:Key="TitleBarButtonBackgroundBrush" Color="{DynamicResource TitleBarButtonBackgroundColor}" />
+                    <SolidColorBrush x:Key="TitleBarButtonHoverBrush" Color="{DynamicResource TitleBarButtonHoverColor}" />
+                    <SolidColorBrush x:Key="TitleBarForegroundBrush" Color="{DynamicResource TitleBarForegroundColor}" />
+                    <!-- 阴影资源 -->
+                    <DropShadowEffect x:Key="SmallShadow" BlurRadius="5" Color="{DynamicResource ShadowColor}"/>
+                    <DropShadowEffect x:Key="MediumShadow" BlurRadius="8" Color="{DynamicResource ShadowColor}"/>
+                    <DropShadowEffect x:Key="LargeShadow" BlurRadius="12" Color="{DynamicResource ShadowColor}"/>
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
+        </ResourceDictionary>
+    </Application.Resources>
     <Application.Styles>
         <FluentTheme />
         <semi:SemiTheme />

--- a/toolsrc/MetahookInstaller/MetahookInstallerAvalonia/App.axaml.cs
+++ b/toolsrc/MetahookInstaller/MetahookInstallerAvalonia/App.axaml.cs
@@ -1,6 +1,7 @@
 ﻿using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
+using Avalonia.Styling;
 using MetahookInstallerAvalonia.ViewModels;
 using MetahookInstallerAvalonia.Views;
 using System;
@@ -23,6 +24,16 @@ public partial class App : Application
         {
             string lang = File.ReadAllText(settingPath);
             Lang.Resources.Culture = new CultureInfo(lang);
+        }
+        var themePath = Path.Combine(".", "theme");
+        if (File.Exists(themePath))
+        {
+            RequestedThemeVariant = File.ReadAllText(themePath).Trim() switch
+            {
+                "Light" => ThemeVariant.Light,
+                "Dark" => ThemeVariant.Dark,
+                _ => ThemeVariant.Default,
+            };
         }
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {

--- a/toolsrc/MetahookInstaller/MetahookInstallerAvalonia/Lang/Resources.Designer.cs
+++ b/toolsrc/MetahookInstaller/MetahookInstallerAvalonia/Lang/Resources.Designer.cs
@@ -329,7 +329,34 @@ namespace MetahookInstallerAvalonia.Lang {
                 return ResourceManager.GetString("MainMenuTitle", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   查找类似 Dark 的本地化字符串。
+        /// </summary>
+        public static string Theme_Dark {
+            get {
+                return ResourceManager.GetString("Theme_Dark", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   查找类似 Light 的本地化字符串。
+        /// </summary>
+        public static string Theme_Light {
+            get {
+                return ResourceManager.GetString("Theme_Light", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   查找类似 System 的本地化字符串。
+        /// </summary>
+        public static string Theme_System {
+            get {
+                return ResourceManager.GetString("Theme_System", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   查找类似 Mod Path: 的本地化字符串。
         /// </summary>

--- a/toolsrc/MetahookInstaller/MetahookInstallerAvalonia/Lang/Resources.resx
+++ b/toolsrc/MetahookInstaller/MetahookInstallerAvalonia/Lang/Resources.resx
@@ -264,4 +264,13 @@
   <data name="UninstallationFailed" xml:space="preserve">
     <value>Uninstallation failed due to an error.</value>
   </data>
+  <data name="Theme_System" xml:space="preserve">
+    <value>System</value>
+  </data>
+  <data name="Theme_Light" xml:space="preserve">
+    <value>Light</value>
+  </data>
+  <data name="Theme_Dark" xml:space="preserve">
+    <value>Dark</value>
+  </data>
 </root>

--- a/toolsrc/MetahookInstaller/MetahookInstallerAvalonia/Lang/Resources.zh-CN.resx
+++ b/toolsrc/MetahookInstaller/MetahookInstallerAvalonia/Lang/Resources.zh-CN.resx
@@ -264,4 +264,13 @@
   <data name="UninstallationFailed" xml:space="preserve">
     <value>卸载失败，发生错误。</value>
   </data>
+  <data name="Theme_System" xml:space="preserve">
+    <value>跟随系统</value>
+  </data>
+  <data name="Theme_Light" xml:space="preserve">
+    <value>浅色</value>
+  </data>
+  <data name="Theme_Dark" xml:space="preserve">
+    <value>深色</value>
+  </data>
 </root>

--- a/toolsrc/MetahookInstaller/MetahookInstallerAvalonia/Styles/ViewStyles.axaml
+++ b/toolsrc/MetahookInstaller/MetahookInstallerAvalonia/Styles/ViewStyles.axaml
@@ -4,35 +4,6 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <Styles.Resources>
-        <Color x:Key="BackgroundColor">#00000000</Color>
-        <Color x:Key="BackgroundAcrylicColor">#11F9F9F9</Color>
-        <Color x:Key="SurfaceColor">#11FFFFFF</Color>
-        <Color x:Key="SurfaceLightColor">#F5F5F5</Color>
-        <Color x:Key="SurfaceAcrylicColor">#66FFFFFF</Color>
-        <Color x:Key="PrimaryColor">#3498DB</Color>
-        <Color x:Key="PrimaryLightColor">#E6F4FF</Color>
-        <Color x:Key="TextPrimaryColor">#2C3E50</Color>
-        <Color x:Key="TextSecondaryColor">#555555</Color>
-        <Color x:Key="BorderColor">#EEEEEE</Color>
-        <Color x:Key="BorderLightColor">#DDDDDD</Color>
-        <Color x:Key="ShadowColor">#15000000</Color>
-        <!-- 派生资源 -->
-        <SolidColorBrush x:Key="BackgroundBrush" Color="{DynamicResource BackgroundColor}" />
-        <SolidColorBrush x:Key="BackgroundAcrylicBrush" Color="{DynamicResource BackgroundAcrylicColor}" />
-        <SolidColorBrush x:Key="SurfaceBrush" Color="{DynamicResource SurfaceColor}" />
-        <SolidColorBrush x:Key="SurfaceLightBrush" Color="{DynamicResource SurfaceLightColor}" />
-        <SolidColorBrush x:Key="SurfaceAcrylicBrush" Color="{DynamicResource SurfaceAcrylicColor}" />
-        <SolidColorBrush x:Key="PrimaryBrush" Color="{DynamicResource PrimaryColor}" />
-        <SolidColorBrush x:Key="PrimaryLightBrush" Color="{DynamicResource PrimaryLightColor}" />
-        <SolidColorBrush x:Key="TextPrimaryBrush" Color="{DynamicResource TextPrimaryColor}" />
-        <SolidColorBrush x:Key="TextSecondaryBrush" Color="{DynamicResource TextSecondaryColor}" />
-        <SolidColorBrush x:Key="BorderBrush" Color="{DynamicResource BorderColor}" />
-        <SolidColorBrush x:Key="BorderLightBrush" Color="{DynamicResource BorderLightColor}" />
-        <!-- 阴影资源 -->
-        <DropShadowEffect x:Key="SmallShadow" BlurRadius="5" Color="{DynamicResource ShadowColor}"/>
-        <DropShadowEffect x:Key="MediumShadow" BlurRadius="8" Color="{DynamicResource ShadowColor}"/>
-        <DropShadowEffect x:Key="LargeShadow" BlurRadius="12" Color="{DynamicResource ShadowColor}"/>
-
         <behaviors:ItemsListBoxDropHandler x:Key="ItemsDropHandler" />
     </Styles.Resources>
  <!-- 基础样式 -->

--- a/toolsrc/MetahookInstaller/MetahookInstallerAvalonia/ViewModels/MainViewModel.cs
+++ b/toolsrc/MetahookInstaller/MetahookInstallerAvalonia/ViewModels/MainViewModel.cs
@@ -1,5 +1,7 @@
-﻿using Avalonia.Controls.Notifications;
+﻿using Avalonia;
+using Avalonia.Controls.Notifications;
 using Avalonia.Media.Imaging;
+using Avalonia.Styling;
 using MetahookInstallerAvalonia.Handler;
 using MetahookInstallerAvalonia.Lang;
 using Microsoft.Win32;
@@ -754,6 +756,9 @@ public class MainViewModel : ViewModelBase
     private readonly ICommand _changeLanguage;
     public ICommand ChangeLanguageCommand => _changeLanguage;
 
+    private readonly ICommand _changeTheme;
+    public ICommand ChangeThemeCommand => _changeTheme;
+
     private readonly ICommand _toastWarning;
     public ICommand ToastWarningCommand => _toastWarning;
 
@@ -930,6 +935,27 @@ public class MainViewModel : ViewModelBase
                    Process.Start(startInfo);
                    Environment.Exit(0);
                }
+           },
+           _ => true
+        );
+        _changeTheme = new Command(
+           obj =>
+           {
+               if (obj is not string theme)
+               {
+                   return;
+               }
+               if (Application.Current is { } app)
+               {
+                   app.RequestedThemeVariant = theme switch
+                   {
+                       "Light" => ThemeVariant.Light,
+                       "Dark" => ThemeVariant.Dark,
+                       _ => ThemeVariant.Default,
+                   };
+               }
+               var settingPath = Path.Combine(".", "theme");
+               File.WriteAllText(settingPath, theme);
            },
            _ => true
         );

--- a/toolsrc/MetahookInstaller/MetahookInstallerAvalonia/Views/MainWindow.axaml
+++ b/toolsrc/MetahookInstaller/MetahookInstallerAvalonia/Views/MainWindow.axaml
@@ -12,7 +12,7 @@ x:Class="MetahookInstallerAvalonia.Views.MainWindow"
 x:DataType="vm:MainViewModel"
 Icon="/Assets/avalonia-logo.ico"
 TransparencyLevelHint="AcrylicBlur"
-Background="#99FFFFFF"
+Background="{DynamicResource WindowBackgroundBrush}"
 ExtendClientAreaToDecorationsHint="True"
 ExtendClientAreaTitleBarHeightHint="-1"
 ExtendClientAreaChromeHints="NoChrome"
@@ -23,21 +23,21 @@ CornerRadius="8">
   <Style Selector="u|IconButton.title-bar-btn">
     <Setter Property="Width" Value="36"/>
     <Setter Property="Height" Value="36"/>
-    <Setter Property="Background" Value="#DDDDDDDD"/>
-    <Setter Property="Foreground" Value="#FF111111"/>
+    <Setter Property="Background" Value="{DynamicResource TitleBarButtonBackgroundBrush}"/>
+    <Setter Property="Foreground" Value="{DynamicResource TitleBarForegroundBrush}"/>
     <Setter Property="FontSize" Value="16"/>
     <Setter Property="Cursor" Value="Hand"/>
     <Setter Property="Opacity" Value="0.8"/>
   </Style>
   <Style Selector="u|IconButton.title-bar-btn:pointerover">
-    <Setter Property="Background" Value="#334155"/>
+    <Setter Property="Background" Value="{DynamicResource TitleBarButtonHoverBrush}"/>
   </Style>
   <Style Selector="u|IconButton.breadcrumb-bar-btn">
     <Setter Property="Width" Value="14"/>
     <Setter Property="Height" Value="14"/>
     <Setter Property="Padding" Value="0"/>
     <Setter Property="Background" Value="#00000000"/>
-    <Setter Property="Foreground" Value="#FF111111"/>
+    <Setter Property="Foreground" Value="{DynamicResource TitleBarForegroundBrush}"/>
     <Setter Property="FontSize" Value="8"/>
     <Setter Property="Cursor" Value="Hand"/>
     <Setter Property="Opacity" Value="0.8"/>
@@ -48,7 +48,7 @@ CornerRadius="8">
   <Style Selector="TextBlock.title-text">
     <Setter Property="FontSize" Value="14"/>
     <Setter Property="FontWeight" Value="Medium"/>
-    <Setter Property="Foreground" Value="#FF111111"/>
+    <Setter Property="Foreground" Value="{DynamicResource TitleBarForegroundBrush}"/>
     <Setter Property="Opacity" Value="0.9"/>
   </Style>
 </Window.Styles>
@@ -78,6 +78,10 @@ CornerRadius="8">
     M11 4H6C4.93913 4 3.92178 4.42142 3.17163 5.17157C2.42149 5.92172 2 6.93913 2 8V18C2 19.0609 2.42149 20.0783 3.17163 20.8284C3.92178 21.5786 4.93913 22 6 22H17C19.21 22 20 20.2 20 18V13
   </StreamGeometry>
   <StreamGeometry x:Key="local_language_regular">M12.75 1.99997C12.3358 1.99997 12 2.33576 12 2.74997C12 3.16418 12.3358 3.49997 12.75 3.49997H18.5V6.30516C18.5 8.05427 16.751 9.49997 14.75 9.49997C14.3358 9.49997 14 9.83576 14 10.25C14 10.6642 14.3358 11 14.75 11C17.3135 11 20 9.12564 20 6.30516V2.74997C20 2.33576 19.6642 1.99997 19.25 1.99997H12.75Z M10.6929 7.46279C10.5767 7.1826 10.3032 6.99994 9.99994 6.99997C9.69664 7 9.42321 7.18271 9.30712 7.46292L2.05712 24.963C1.89859 25.3457 2.08029 25.7844 2.46296 25.943C2.84563 26.1015 3.28437 25.9198 3.44291 25.5371L5.53053 20.498H14.4723L16.5611 25.5372C16.7197 25.9199 17.1585 26.1015 17.5411 25.9429C17.9238 25.7843 18.1054 25.3455 17.9468 24.9629L15.7433 19.6469C15.7255 19.5153 15.6737 19.3946 15.5969 19.2938L10.6929 7.46279ZM13.8505 18.998H6.15195L10.0002 9.70908L13.8505 18.998Z M22.2516 1.99997C22.6658 1.99997 23.0016 2.33576 23.0016 2.74997V8.49997H25.25C25.6642 8.49997 26 8.83576 26 9.24997C26 9.66418 25.6642 9.99997 25.25 9.99997H23.0016V19.2495C23.0016 19.6637 22.6658 19.9995 22.2516 19.9995C21.8374 19.9995 21.5016 19.6637 21.5016 19.2495V9.29915C21.5005 9.28289 21.5 9.26649 21.5 9.24997C21.5 9.23344 21.5005 9.21704 21.5016 9.20079V2.74997C21.5016 2.33576 21.8374 1.99997 22.2516 1.99997Z</StreamGeometry>
+  <StreamGeometry x:Key="theme_regular">
+    M12,2 C17.523,2 22,6.477 22,12 C22,17.523 17.523,22 12,22 C6.477,22 2,17.523 2,12 C2,6.477 6.477,2 12,2 Z M12,4.5 C7.858,4.5 4.5,7.858 4.5,12 C4.5,16.142 7.858,19.5 12,19.5 Z
+    M12,7 C14.761,7 17,9.239 17,12 C17,14.761 14.761,17 12,17 Z
+  </StreamGeometry>
   <StreamGeometry x:Key="github_regular">
     M4.0744 2.9938C4.13263 1.96371 4.37869 1.51577 5.08432 1.15606C5.84357 0.768899 7.04106 0.949072 8.45014 1.66261C9.05706 1.97009 9.11886 1.97635 10.1825 1.83998C11.5963 1.65865 13.4164 1.65929 14.7213 1.84164C15.7081 1.97954 15.7729 1.97265 16.3813 1.66453C18.3814 0.651679 19.9605 0.71795 20.5323 1.8387C20.8177 2.39812 20.8707 3.84971 20.6494 5.04695C20.5267 5.71069 20.5397 5.79356 20.8353 6.22912C22.915 9.29385 21.4165 14.2616 17.8528 16.1155C17.5801 16.2574 17.3503 16.3452 17.163 16.4167C16.5879 16.6363 16.4133 16.703 16.6247 17.7138C16.7265 18.2 16.8491 19.4088 16.8973 20.4002C16.9844 22.1922 16.9831 22.2047 16.6688 22.5703C16.241 23.0676 15.6244 23.076 15.2066 22.5902C14.9341 22.2734 14.9075 22.1238 14.9075 20.9015C14.9075 19.0952 14.7095 17.8946 14.2417 16.8658C13.6854 15.6415 14.0978 15.185 15.37 14.9114C17.1383 14.531 18.5194 13.4397 19.2892 11.8146C20.0211 10.2698 20.1314 8.13501 18.8082 6.83668C18.4319 6.3895 18.4057 5.98446 18.6744 4.76309C18.7748 4.3066 18.859 3.71768 18.8615 3.45425C18.8653 3.03823 18.8274 2.97541 18.5719 2.97541C18.4102 2.97541 17.7924 3.21062 17.1992 3.49805L16.2524 3.95695C16.1663 3.99866 16.07 4.0147 15.975 4.0038C13.5675 3.72746 11.2799 3.72319 8.86062 4.00488C8.76526 4.01598 8.66853 3.99994 8.58215 3.95802L7.63585 3.49882C7.04259 3.21087 6.42482 2.97541 6.26317 2.97541C5.88941 2.97541 5.88379 3.25135 6.22447 4.89078C6.43258 5.89203 6.57262 6.11513 5.97101 6.91572C5.06925 8.11576 4.844 9.60592 5.32757 11.1716C5.93704 13.1446 7.4295 14.4775 9.52773 14.9222C10.7926 15.1903 11.1232 15.5401 10.6402 16.9905C10.26 18.1319 10.0196 18.4261 9.46707 18.4261C8.72365 18.4261 8.25796 17.7821 8.51424 17.1082C8.62712 16.8112 8.59354 16.7795 7.89711 16.5255C5.77117 15.7504 4.14514 14.0131 3.40172 11.7223C2.82711 9.95184 3.07994 7.64739 4.00175 6.25453C4.31561 5.78028 4.32047 5.74006 4.174 4.83217C4.09113 4.31822 4.04631 3.49103 4.0744 2.9938Z
     M3.33203 15.9454C3.02568 15.4859 2.40481 15.3617 1.94528 15.6681C1.48576 15.9744 1.36158 16.5953 1.66793 17.0548C1.8941 17.3941 2.16467 17.6728 2.39444 17.9025C2.4368 17.9449 2.47796 17.9858 2.51815 18.0257C2.71062 18.2169 2.88056 18.3857 3.05124 18.5861C3.42875 19.0292 3.80536 19.626 4.0194 20.6962C4.11474 21.1729 4.45739 21.4297 4.64725 21.5419C4.85315 21.6635 5.07812 21.7352 5.26325 21.7819C5.64196 21.8774 6.10169 21.927 6.53799 21.9559C7.01695 21.9877 7.53592 21.998 7.99999 22.0008C8.00033 22.5527 8.44791 23.0001 8.99998 23.0001C9.55227 23.0001 9.99998 22.5524 9.99998 22.0001V21.0001C9.99998 20.4478 9.55227 20.0001 8.99998 20.0001C8.90571 20.0001 8.80372 20.0004 8.69569 20.0008C8.10883 20.0026 7.34388 20.0049 6.67018 19.9603C6.34531 19.9388 6.07825 19.9083 5.88241 19.871C5.58083 18.6871 5.09362 17.8994 4.57373 17.2891C4.34391 17.0194 4.10593 16.7834 3.91236 16.5914C3.87612 16.5555 3.84144 16.5211 3.80865 16.4883C3.5853 16.265 3.4392 16.1062 3.33203 15.9454Z
@@ -115,7 +119,7 @@ CornerRadius="8">
     M25.38,28H4a1,1,0,0,1-1-1.21l3-14A1,1,0,0,1,7,12H30a1,1,0,0,1,1,1.21L28.32,25.63A3,3,0,0,1,25.38,28ZM5.24,26H25.38a1,1,0,0,0,1-.79L28.76,14h-21Z
   </StreamGeometry>
 </Window.Resources>
-<DockPanel Background="#BBEEEEEE">
+<DockPanel Background="{DynamicResource TitleBarBackgroundBrush}">
   <Grid DockPanel.Dock="Top" Height="48"
   Background="Transparent"
   PointerPressed="TitleBar_PointerPressed"
@@ -157,6 +161,27 @@ CornerRadius="8">
           </MenuFlyout>
         </u:IconButton.Flyout>
       </u:IconButton>
+      <u:IconButton Classes="breadcrumb-bar-btn" Icon="{StaticResource theme_regular}">
+        <u:IconButton.Flyout>
+          <MenuFlyout>
+            <MenuItem Command="{CompiledBinding ChangeThemeCommand}" CommandParameter="System">
+              <MenuItem.Header>
+                <Label Content="{x:Static lang:Resources.Theme_System}"/>
+              </MenuItem.Header>
+            </MenuItem>
+            <MenuItem Command="{CompiledBinding ChangeThemeCommand}" CommandParameter="Light">
+              <MenuItem.Header>
+                <Label Content="{x:Static lang:Resources.Theme_Light}"/>
+              </MenuItem.Header>
+            </MenuItem>
+            <MenuItem Command="{CompiledBinding ChangeThemeCommand}" CommandParameter="Dark">
+              <MenuItem.Header>
+                <Label Content="{x:Static lang:Resources.Theme_Dark}"/>
+              </MenuItem.Header>
+            </MenuItem>
+          </MenuFlyout>
+        </u:IconButton.Flyout>
+      </u:IconButton>
     </u:Breadcrumb>
     <u:IconButton
     Classes="title-bar-btn"
@@ -172,7 +197,7 @@ CornerRadius="8">
     />
   </StackPanel>
 </Grid>
-<Grid Margin="20" Background="#CCFFFFFF">
+<Grid Margin="20" Background="{DynamicResource ContentBackgroundBrush}">
   <views:MainView />
 </Grid>
 </DockPanel>


### PR DESCRIPTION
## Summary

Implements #861. Adds a theme-aware palette and a System / Light / Dark selector to MetahookInstaller.

- Moves the palette out of `Styles/ViewStyles.axaml` into `App.axaml` `Application.Resources` as `ResourceDictionary.ThemeDictionaries` with `Light` / `Dark` variants. App-level scope is required because these brushes are consumed by the window/title bar, not only by `MainView`.
- Replaces the hardcoded window background, acrylic tint, dock/content backgrounds, title-bar button/text and hover colors in `MainWindow.axaml` with `DynamicResource` keys; adds a `theme_regular` icon and a theme selector flyout mirrored on the existing language menu.
- Persists the selection to a `theme` file and applies it from `App.axaml.cs` on startup via `RequestedThemeVariant`; `ChangeThemeCommand` applies it at runtime without a restart.
- Adds `Theme_System` / `Theme_Light` / `Theme_Dark` strings (en + zh-CN).

## Test plan

- [x] `dotnet build MetahookInstallerAvalonia.Desktop.csproj` — 0 errors (pre-existing warnings only).
- [x] Launch with `theme=Dark` → window, title bar, tab strip, cards and text all render dark; no leftover light patches.
- [x] Launch with `theme=Light` → renders identically to the previous light palette.
- [x] Startup read of the persisted `theme` file verified for both variants.
- [ ] Manual click-through of the theme flyout at runtime and toast/flyout legibility under each variant (not automated).

Closes #861