### PR TITLE
feat(gamedata): support dataset schema 5 and scalar symbols (API 111)

### DIFF
--- a/docs/MetaHook.md
+++ b/docs/MetaHook.md
@@ -222,13 +222,15 @@ During the engine's call to all plugins' `LoadEngine`, a "transaction" will be o
 
 The transaction opening timing includes: during the engine's calls to all plugins' `LoadEngine` and `LoadClient`, during the engine's call to the client's `HUD_GetStudioModelInterface`, and during the DllLoadNotification period.
 
-# Game Symbol API (API 109, extended in API 110)
+# Game Symbol API (API 109, extended in API 110 and API 111)
 
 MetaHookSv API version 109 adds a public game symbol query/resolution API. It is backed by a local gamedata catalog that is synchronized at build time (see `scripts/sync-gamedata.py`) and read at runtime from `<game>\<mod>\metahook\gamedata\`.
 
 API version 110 appends `MH_GAMESYMBOL_KIND_PATCH` and the `IsGameSymbolAvailable` slot without moving any existing slot.
 
-Plugins must check `g_pInterface->MetaHookAPIVersion >= 109` (or `>= 110` for the API 110 additions) before calling these functions. All returned string/pattern pointers are owned by MetaHook and remain valid until process exit; do not free or modify them.
+API version 111 appends `MH_GAMESYMBOL_KIND_SCALAR` and the `QueryGameSymbolScalar` slot without moving any existing slot. The gamedata contract moves to dataset schema 5 / source snapshot contract 8 / analysis output contract 3, which is the only accepted generation.
+
+Plugins must check `g_pInterface->MetaHookAPIVersion >= 109` (or `>= 110` / `>= 111` for the API 110 / API 111 additions) before calling these functions. All returned string/pattern pointers are owned by MetaHook and remain valid until process exit; do not free or modify them.
 
 ## Types
 
@@ -240,11 +242,14 @@ typedef enum mh_gamesymbol_kind_e
 	MH_GAMESYMBOL_KIND_UNKNOWN = 0,
 	MH_GAMESYMBOL_KIND_FUNCTION = 1,
 	MH_GAMESYMBOL_KIND_GLOBAL = 2,
-	MH_GAMESYMBOL_KIND_PATCH = 3
+	MH_GAMESYMBOL_KIND_PATCH = 3,
+	MH_GAMESYMBOL_KIND_SCALAR = 4
 } mh_gamesymbol_kind_t;
 ```
 
 `PATCH` denotes a single call/jump instruction address (`patch_rva`) that can be redirected; its signature is metadata only and is never interpreted as a function body or length.
+
+`SCALAR` (API 111) denotes a plain `uint32` value tied to the matched binary identity, not an address. It is never resolved by `ResolveGameSymbol` and its value must not have an image base added or be dereferenced; query it with `QueryGameSymbolScalar`.
 
 ### `mh_gamesymbol_status_t`
 
@@ -307,9 +312,12 @@ typedef struct mh_gamesymbol_s
 | `SearchPatternMasked(base, len, bytes, mask, plen)` | Search with an explicit mask (literal `0x2A` has no special meaning). |
 | `GetGameSymbolStatusString(status)` | Return a static, MetaHook-owned English string for a status. |
 | `IsGameSymbolAvailable(moduleBase, name)` (API 110) | Return `MH_GAMESYMBOL_OK` when the exact, case-sensitive name exists, `MH_GAMESYMBOL_SYMBOL_NOT_FOUND` when it does not, and the original status for every other failure (never converted to "not found"). It does not return an address. |
+| `QueryGameSymbolScalar(moduleBase, name, &value)` (API 111) | Return the `uint32` value of a scalar record. Returns `MH_GAMESYMBOL_KIND_MISMATCH` when the symbol exists with a non-scalar kind. The value is consumed verbatim: no image base, no dereference. |
 
-`QueryGameSymbol` / `QueryGameSymbolByCRC64` require the caller to initialize `outSymbol->cbSize` to `sizeof(mh_gamesymbol_t)`; a smaller value returns `MH_GAMESYMBOL_OUTPUT_TOO_SMALL`. On failure the output fields are zeroed while `cbSize` is preserved.
+`QueryGameSymbol` / `QueryGameSymbolByCRC64` require the caller to initialize `outSymbol->cbSize` to `sizeof(mh_gamesymbol_t)`; a smaller value returns `MH_GAMESYMBOL_OUTPUT_TOO_SMALL`. On failure the output fields are zeroed while `cbSize` is preserved. When the queried symbol is a scalar, `kind` is `MH_GAMESYMBOL_KIND_SCALAR` and every address field is zero; use `QueryGameSymbolScalar` to read the value.
 
 `IsGameSymbolAvailable` accepts no wildcard or numeric-range syntax. Callers that need a contiguous family of numbered records, such as `Cvar_Set_to_Cvar_DirectSet_callsite_0..N`, build each exact name themselves, probe with `IsGameSymbolAvailable`, and call `ResolveGameSymbol` only for names that exist.
+
+Scalars are keyed by the same `(moduleCRC64, symbolName)` identity as address records and are stored in the same catalog. `QueryGameSymbolScalar` returns `MH_GAMESYMBOL_KIND_MISMATCH` for a FUNCTION / GLOBAL / PATCH name, and `ResolveGameSymbol` rejects a scalar name because its `expectedKind` must be FUNCTION, GLOBAL or PATCH. A catalog built from an unsupported dataset generation (anything other than dataset schema 5 / source snapshot contract 8 / analysis output contract 3) is rejected per snapshot and recorded as a diagnostic.
 
 APIs that accept `moduleBase` require the module to remain loaded for the duration of the call. MetaHook invalidates the module CRC cache and any mirror aliases when the module unloads; an address returned by `ResolveGameSymbol` is valid only until that module instance unloads.

--- a/docs/MetaHookCN.md
+++ b/docs/MetaHookCN.md
@@ -291,13 +291,15 @@ MetaHook (V2)版本的 `g_pMetaHookAPI->GetEngineBase()` 对BLOB加密版本的�
 这样就可以允许不同插件同时 `SearchPattern` 和 hook 同一个函数，避免了因为前一个插件提前hook修改了引擎代码导致后一个插件搜索特征码失败等插件之间互相冲突的问题。
 
 事务开启时机：引擎调用所有插件的`LoadEngine`和`LoadClient`期间、引擎调用客户端的 `HUD_GetStudioModelInterface` 期间以及DllLoadNotification期间。
-# 游戏符号 API（API 109，API 110 扩展）
+# 游戏符号 API（API 109，API 110 / API 111 扩展）
 
 MetaHookSv API 版本 109 新增了一套公开的游戏符号查询/解析 API。它由本地 gamedata catalog 支撑：catalog 在构建期同步（见 `scripts/sync-gamedata.py`），运行时从 `<game>\<mod>\metahook\gamedata\` 读取。
 
 API 版本 110 在末尾追加 `MH_GAMESYMBOL_KIND_PATCH` 与 `IsGameSymbolAvailable` 槽位，不移动任何已有槽位。
 
-插件在调用这些函数前应先检查 `g_pInterface->MetaHookAPIVersion >= 109`（使用 API 110 新增内容时需 `>= 110`）。所有返回的字符串/pattern 指针都由 MetaHook 持有、进程退出前有效；请勿释放或修改。
+API 版本 111 在末尾追加 `MH_GAMESYMBOL_KIND_SCALAR` 与 `QueryGameSymbolScalar` 槽位，不移动任何已有槽位。gamedata 契约同步升级为 dataset schema 5 / source snapshot contract 8 / analysis output contract 3，这是唯一接受的代际。
+
+插件在调用这些函数前应先检查 `g_pInterface->MetaHookAPIVersion >= 109`（使用 API 110 / API 111 新增内容时分别需 `>= 110` / `>= 111`）。所有返回的字符串/pattern 指针都由 MetaHook 持有、进程退出前有效；请勿释放或修改。
 
 ## 类型
 
@@ -309,11 +311,14 @@ typedef enum mh_gamesymbol_kind_e
 	MH_GAMESYMBOL_KIND_UNKNOWN = 0,
 	MH_GAMESYMBOL_KIND_FUNCTION = 1,
 	MH_GAMESYMBOL_KIND_GLOBAL = 2,
-	MH_GAMESYMBOL_KIND_PATCH = 3
+	MH_GAMESYMBOL_KIND_PATCH = 3,
+	MH_GAMESYMBOL_KIND_SCALAR = 4
 } mh_gamesymbol_kind_t;
 ```
 
 `PATCH` 表示可被重定向的单条 call/jump 指令地址（`patch_rva`）；其 signature 仅为元数据，不会被当作函数体或长度解释。
+
+`SCALAR`（API 111）表示按 binary identity 绑定的纯 `uint32` 数值，而非地址。它不会被 `ResolveGameSymbol` 解析，其数值不得加 image base、不得解引用，请使用 `QueryGameSymbolScalar` 获取。
 
 ### `mh_gamesymbol_status_t`
 
@@ -376,9 +381,12 @@ typedef struct mh_gamesymbol_s
 | `SearchPatternMasked(base, len, bytes, mask, plen)` | 用显式 mask 搜索（字面 `0x2A` 无特殊含义）。 |
 | `GetGameSymbolStatusString(status)` | 返回 MetaHook 持有的静态英文字符串。 |
 | `IsGameSymbolAvailable(moduleBase, name)`（API 110） | 精确、区分大小写的符号名存在时返回 `MH_GAMESYMBOL_OK`，不存在时返回 `MH_GAMESYMBOL_SYMBOL_NOT_FOUND`，其它失败保留原状态码（绝不转换为“不存在”）。不返回地址。 |
+| `QueryGameSymbolScalar(moduleBase, name, &value)`（API 111） | 返回 scalar 记录的 `uint32` 数值；符号存在但 kind 非 scalar 时返回 `MH_GAMESYMBOL_KIND_MISMATCH`。数值按原样消费：不加 image base、不解引用。 |
 
-`QueryGameSymbol` / `QueryGameSymbolByCRC64` 要求调用方将 `outSymbol->cbSize` 初始化为 `sizeof(mh_gamesymbol_t)`；更小会返回 `MH_GAMESYMBOL_OUTPUT_TOO_SMALL`。失败时输出字段会被清零，同时保留 `cbSize`。
+`QueryGameSymbol` / `QueryGameSymbolByCRC64` 要求调用方将 `outSymbol->cbSize` 初始化为 `sizeof(mh_gamesymbol_t)`；更小会返回 `MH_GAMESYMBOL_OUTPUT_TOO_SMALL`。失败时输出字段会被清零，同时保留 `cbSize`。当查询到的是 scalar 时，`kind` 为 `MH_GAMESYMBOL_KIND_SCALAR` 且所有地址字段为 0，数值请用 `QueryGameSymbolScalar` 获取。
 
 `IsGameSymbolAvailable` 不支持通配符或数字区间语法。需要连续编号记录族（如 `Cvar_Set_to_Cvar_DirectSet_callsite_0..N`）的调用方自行拼接精确名字，先用 `IsGameSymbolAvailable` 探测存在性，仅对存在的名字调用 `ResolveGameSymbol` 取地址。
+
+scalar 与地址型记录共用同一 catalog 与 `(moduleCRC64, symbolName)` identity。对 FUNCTION / GLOBAL / PATCH 名字调用 `QueryGameSymbolScalar` 返回 `MH_GAMESYMBOL_KIND_MISMATCH`；对 scalar 名字调用 `ResolveGameSymbol` 因 `expectedKind` 必须为 FUNCTION / GLOBAL / PATCH 而被拒绝。由不支持的 dataset 代际（非 dataset schema 5 / source snapshot contract 8 / analysis output contract 3）构建的 snapshot 会被逐个拒绝并记为诊断。
 
 接受 `moduleBase` 的 API 要求模块在调用期间保持已加载。模块卸载时 MetaHook 会失效其 CRC 缓存及全部 mirror aliases；`ResolveGameSymbol` 返回的地址仅在该模块加载实例卸载前有效。

--- a/include/metahook.h
+++ b/include/metahook.h
@@ -109,7 +109,7 @@ typedef struct mh_plugininfo_s
 #include <ICommandLine.h>
 #include <IRegistry.h>
 
-#define METAHOOK_API_VERSION 110
+#define METAHOOK_API_VERSION 111
 
 typedef struct hook_s hook_t;
 
@@ -185,7 +185,11 @@ typedef enum mh_gamesymbol_kind_e
 	MH_GAMESYMBOL_KIND_UNKNOWN = 0,
 	MH_GAMESYMBOL_KIND_FUNCTION = 1,
 	MH_GAMESYMBOL_KIND_GLOBAL = 2,
-	MH_GAMESYMBOL_KIND_PATCH = 3
+	MH_GAMESYMBOL_KIND_PATCH = 3,
+	// A scalar is a plain uint32 value tied to the matched binary identity, not
+	// an address. It is never resolved by ResolveGameSymbol; query it with
+	// QueryGameSymbolScalar instead.
+	MH_GAMESYMBOL_KIND_SCALAR = 4
 } mh_gamesymbol_kind_t;
 
 /*
@@ -819,6 +823,18 @@ typedef struct metahook_api_s
 	mh_gamesymbol_status_t (*IsGameSymbolAvailable)(
 		PVOID moduleBase,
 		const char *symbolName);
+
+	/*
+		Purpose: Query a scalar (uint32) gamedata value by module base + canonical name.
+		A scalar is a plain value tied to the matched binary identity: no image base
+		is added and the value must never be dereferenced or treated as an address.
+		Returns MH_GAMESYMBOL_KIND_MISMATCH when the symbol exists with a non-scalar
+		kind; use ResolveGameSymbol for FUNCTION / GLOBAL / PATCH.
+	*/
+	mh_gamesymbol_status_t (*QueryGameSymbolScalar)(
+		PVOID moduleBase,
+		const char *symbolName,
+		uint32_t *outValue);
 
 	// Always terminate with a NULL
 	PVOID Terminator;

--- a/memory/GameData.md
+++ b/memory/GameData.md
@@ -8,6 +8,7 @@ tags:
 - symbol-catalog
 - api-109
 - api-110
+- api-111
 - crc64
 ---
 
@@ -15,24 +16,24 @@ tags:
 
 ## Overview
 
-GameData 是 launcher 与 V3/V4 插件共享的本地游戏符号目录（catalog）组件：从 `<game>\<mod>\metahook\gamedata\index.json` 读取并冻结一份只读符号表，按 `(moduleCRC64, symbolName)` 查询符号元数据，并通过 `moduleBase` 懒计算模块原始文件的 CRC-64/XZ。公共接口以 MetaHook API 109 暴露（`metahook_api_t` 尾部的 6 个函数槽），API 110 追加 `MH_GAMESYMBOL_KIND_PATCH` 与 `IsGameSymbolAvailable` 槽位（不改动旧槽位偏移）。
+GameData 是 launcher 与 V3/V4 插件共享的本地游戏符号目录（catalog）组件：从 `<game>\<mod>\metahook\gamedata\index.json` 读取并冻结一份只读符号表，按 `(moduleCRC64, symbolName)` 查询符号元数据，并通过 `moduleBase` 懒计算模块原始文件的 CRC-64/XZ。公共接口以 MetaHook API 109 暴露（`metahook_api_t` 尾部的 6 个函数槽），API 110 追加 `MH_GAMESYMBOL_KIND_PATCH` 与 `IsGameSymbolAvailable` 槽位，API 111 追加 `MH_GAMESYMBOL_KIND_SCALAR` 与 `QueryGameSymbolScalar` 槽位（均不改动旧槽位偏移）。
 
 ## Responsibilities
 
 - 构建并冻结只读 catalog（`GameData::Initialize`），初始化后不可重载，所有返回指针在进程退出前有效。
-- 校验 index（schema v4）与每个 snapshot（schema v4 / `source.snapshotSchemaVersion` v7）的路径安全、size、SHA-256（`Chocobo1::SHA2_256`）。
-- 只提取 `platform == "windows"` 的记录，将 `function` / `global` / `patch` payload 规范化为 `GameSymbolRecord`；单 snapshot 失败隔离为 diagnostics，不破坏整个 catalog。`patch` 记录正规化为 `MH_GAMESYMBOL_KIND_PATCH`，地址取 `patch_rva`，不把 signature 当函数长度。
+- 校验 index（schema v4）与每个 snapshot（dataset schema v5 / `source.snapshotSchemaVersion` v8 / `source.analysisOutputContractVersion` v3）的路径安全、size、SHA-256（`Chocobo1::SHA2_256`）。旧代际（dataset schema 4 / source contract 7）被明确拒绝并记为 diagnostic。
+- 只提取 `platform == "windows"` 的记录，将 `function` / `global` / `patch` / `scalar` payload 规范化为 `GameSymbolRecord`；单 snapshot 失败隔离为 diagnostics，不破坏整个 catalog。`patch` 记录正规化为 `MH_GAMESYMBOL_KIND_PATCH`，地址取 `patch_rva`，不把 signature 当函数长度。`scalar` 记录正规化为 `MH_GAMESYMBOL_KIND_SCALAR`，只保留 uint32 `scalar_value`（地址字段全 0，不加 image base、不解引用）。
 - 将 signature 文本编译为 `(bytes, mask, legacyPattern)` 三态。
 - 按 `moduleBase` 管理 `ModuleIdentity`（普通 PE / Blob 文件 / None），懒计算并缓存模块 CRC-64/XZ，处理 mirror alias 与 unload 失效。
-- 实现公共 API：`MH_GetModuleCRC64`、`MH_QueryGameSymbol`、`MH_QueryGameSymbolByCRC64`、`MH_ResolveGameSymbol`、`MH_SearchPatternMasked`、`MH_GetGameSymbolStatusString`，以及 API 110 的 `MH_IsGameSymbolAvailable`（仅返回状态码：存在 `OK`、不存在 `SYMBOL_NOT_FOUND`、其它失败保留原状态；不返回地址）。
+- 实现公共 API：`MH_GetModuleCRC64`、`MH_QueryGameSymbol`、`MH_QueryGameSymbolByCRC64`、`MH_ResolveGameSymbol`、`MH_SearchPatternMasked`、`MH_GetGameSymbolStatusString`，API 110 的 `MH_IsGameSymbolAvailable`（仅返回状态码：存在 `OK`、不存在 `SYMBOL_NOT_FOUND`、其它失败保留原状态；不返回地址），以及 API 111 的 `MH_QueryGameSymbolScalar`（按 `moduleBase` + 名字返回 uint32；非 scalar kind 返回 `KIND_MISMATCH`）。
 - 提供 launcher 内部 getter `GameData::GetGameVersion(moduleCRC64, &gameVersion)`（不进入 `metahook_api_t`），用于按引擎模块 CRC 反查 catalog 中的 gameVersion。
 - 提供 `GameData::RegisterModuleFileSource`（Blob engine）与 `RegisterMirrorAlias` 供 launcher 注册模块来源。
 
 ## Involved Files & Symbols
 
-- `src/GameData.h` — `GameData` namespace 声明（`Initialize`/`QueryByCRC64`/`GetGameVersion`/`GetModuleCRC64`/`RegisterModuleFileSource`/`RegisterMirrorAlias`/`InvalidateModule`/`ResetModuleIdentities`）与公共 `MH_*` 入口。
-- `src/GameData.cpp` — 实现 `GameDataCatalog` 构建（`Initialize`/`LoadSnapshot`/`ValidateIndex`）、签名解析 `ParseSignature`、payload 规范化 `NormalizeFunction`/`NormalizeGlobal`/`NormalizePatch`、模块哈希状态机 `GetModuleCRC64`/`ComputeCrc64FromFile`、公共 API 与 `MH_GetGameSymbolStatusString`。
-- `include/metahook.h` — `METAHOOK_API_VERSION 110`、`mh_gamesymbol_kind_t`（含 `MH_GAMESYMBOL_KIND_PATCH`）/`mh_gamesymbol_status_t`/`mh_pattern_t`/`mh_gamesymbol_t`、`metahook_api_t` 新增的 7 个函数槽（第 6 个为 `IsGameSymbolAvailable`）。
+- `src/GameData.h` — `GameData` namespace 声明（`Initialize`/`QueryByCRC64`/`QueryScalarByCRC64`/`GetGameVersion`/`GetModuleCRC64`/`RegisterModuleFileSource`/`RegisterMirrorAlias`/`InvalidateModule`/`ResetModuleIdentities`）与公共 `MH_*` 入口。
+- `src/GameData.cpp` — 实现 `GameDataCatalog` 构建（`Initialize`/`LoadSnapshot`/`ValidateIndex`）、签名解析 `ParseSignature`、payload 规范化 `NormalizeFunction`/`NormalizeGlobal`/`NormalizePatch`/`NormalizeScalar`、模块哈希状态机 `GetModuleCRC64`/`ComputeCrc64FromFile`、公共 API 与 `MH_GetGameSymbolStatusString`。
+- `include/metahook.h` — `METAHOOK_API_VERSION 111`、`mh_gamesymbol_kind_t`（含 `MH_GAMESYMBOL_KIND_PATCH` / `MH_GAMESYMBOL_KIND_SCALAR`）/`mh_gamesymbol_status_t`/`mh_pattern_t`/`mh_gamesymbol_t`、`metahook_api_t` 新增的 8 个函数槽（第 6 个为 `IsGameSymbolAvailable`，第 8 个为 `QueryGameSymbolScalar`）。
 - `src/metahook.cpp` — launcher 集成：`MH_LoadEngine_FormatModuleIdentity` / `MH_LoadEngine_ReportSymbolFailure` / `MH_LoadEngine_ResolveSymbol` / `MH_LoadEngine_ResolveGlobalOperand`、`MH_LoadEngine_DetermineEngineType` / `MH_LoadEngine_FindCvarDirectSet` / `MH_LoadEngine_PatchCvarCallbacks` / `MH_LoadEngine_FindLoadBlobClient`（均 gamedata-only），以及 `MH_LoadEngine` 中 catalog 初始化与来源注册。
 - `src/LoadDllNotification.cpp` / `.h` — DLL 加/卸载通知中调用 `GameData::InvalidateModule`（第 144、212 行）与 `MH_IsInLdrCriticalRegion`（第 66 行）。
 - `scripts/sync-gamedata.py` — Pre-build 从固定 HTTPS index 下载、校验并事务式替换打包目录。
@@ -62,7 +63,7 @@ flowchart TD
     B --> C["Read + validate index.json (schema v4)"]
     C --> D["Per version entry: LoadSnapshot"]
     D --> E["Verify size + SHA-256 (SHA2_256)"]
-    E --> F["Parse snapshot JSON (schema v4 / source v7)"]
+    E --> F["Parse snapshot JSON (dataset v5 / source v8 / analysis v3)"]
     F --> G["Normalize 'windows' records -> GameSymbolRecord"]
     G --> H["Build crc64 -> ModuleCatalog -> symbolName map"]
     H --> I["Freeze catalog, available=true"]
@@ -96,11 +97,13 @@ flowchart TD
 - signature 只接受空格分隔的两位十六进制字节与 `??` wildcard；`bytes + mask` 为权威无损表示（`mask[i]==0` 通配），`legacyPattern` 仅在签名不含字面量 `0x2A` 字节时生成，否则为 `NULL`。
 - 符号名查找区分大小写；键为 `(moduleCRC64, symbolName)`。完全相同的重复记录去重，内容冲突标记 `CATALOG_CONFLICT`；未类型化 kind 标记 `unsupportedKind` 查询返回 `UNSUPPORTED_KIND`。
 - `patch` 记录只消费 `patch_rva`（`symbolSize`/`signatureRva`/指令字段均为 0），不按 signature 搜索内存，也不改写长度；`MH_ResolveGameSymbol` 现在接受 `FUNCTION`/`GLOBAL`/`PATCH` 三种 expected kind。
+- `scalar` 记录只保留 uint32 `scalar_value`，地址字段全 0；`QueryGameSymbolScalar`（`MH_QueryGameSymbolScalar` / `QueryScalarByCRC64`）返回 `KIND_MISMATCH` 当名字对应非 scalar kind，`ResolveGameSymbol` 因 `expectedKind` 只能为 `FUNCTION`/`GLOBAL`/`PATCH` 而拒绝 scalar。经 `QueryGameSymbol` 查询 scalar 时 `kind == MH_GAMESYMBOL_KIND_SCALAR`、地址字段全 0。
 - `IsGameSymbolAvailable` 是纯存在性查询（`moduleBase` + 精确名字），不返回地址、不做 expected kind 检查；`OK`/`SYMBOL_NOT_FOUND` 之外的失败保留原状态码。连续编号的 call-site 由调用方自行拼接名字并循环探测，API 不做枚举。
 - `cbSize` 契约：调用方先置 `cbSize = sizeof(mh_gamesymbol_t)`，过小返回 `OUTPUT_TOO_SMALL`；失败时输出字段清零但保留 `cbSize`。
 - `ResolveGameSymbol` 只接受 `FUNCTION`/`GLOBAL`，并做 rva 与 `rva + symbolSize` 的溢出和映像边界检查；不校验内存 signature，也不做跨版本扫描。
 - 迁移历史（规则见上文“架构约定”）：ResourceReplacer（计划见 `docs/plans/resource-replacer-gamedata-migration-plan.md`，2026-09-06 已实施——4 符号 gamedata-only、旧扫描全删、`COMMON_REQUIRED` 门禁已纳入，详见 [[resource-replacer-privatevars]]）；HeapPatch（2026-09-07 已实施——`Sys_InitMemory` gamedata-only、旧扫描全删、`COMMON_REQUIRED` 门禁已纳入，函数体内 heap-limit immediate 仍走有界 disasm，详见 [[heap-patch-privatevars]]）；launcher `src/metahook.cpp`（issue #850，2026-09-08 已实施——引擎族改为 catalog gameVersion → 前缀/版本阈值规则，`Cvar_DirectSet`、`cvar_hooks`、`Cvar_Set_to_Cvar_DirectSet_callsite_N`、`NLoadBlob`、`FreeBlob` 全部 gamedata-only，旧字符串/反查/pattern 扫描与 `MH_DisasmRanges` 定位全部删除，详见 [[metahook-privatevars]]）；HeapPatch / ResourceReplacer / PrecacheManager 三个插件（issue #853，2026-09-09 已实施——`Sys_InitMemory_HeapLimitPatches_N`、`S_LoadSound_to_FS_Open_callsite_N`、`Mod_LoadModel_to_FS_Open_callsite_N` 与 `cl_resourcesonhand` 全部 gamedata-only；`DisasmRanges` 控制流遍历、`"rb"` / `#GameUI_PrecachingResources` 字符串搜索、push pattern、`FindFSOpenCallSites`、`ConvertDllInfoSpace` 与镜像空间准备全部删除，详见 [[heap-patch-privatevars]] [[resource-replacer-privatevars]] [[precache-manager-privatevars]]）；ThreadGuard / SCModelDownloader 两个插件（issue #855，2026-09-09 已实施——ThreadGuard 的 `engine` GLOBAL 与 SCModelDownloader 的 `R_StudioDrawPlayer` / `studioapi_SetupPlayerModel` / `Host_IsSinglePlayerGame` FUNCTION、`DM_PlayerState` / `cl_players_model` GLOBAL 全部 gamedata-only；SCModelDownloader 改为 inline hook 两个 caller 并重建触发谓词，`R_StudioChangePlayerModel` FUNCTION 与 call-site PATCH 依赖、签名搜索、CFG 遍历、`ConvertDllInfoSpace` 与镜像空间准备全部删除，详见 [[threadguard-privatevars]] [[scmodeldownloader-privatevars]]）。仅对 gamedata 尚未提供且功能本体需要的指令信息保留相应操作；不能将 call-site 一概视为 gamedata 无法表达，已提供地址的符号必须直接 Resolve。PATCH 记录语义是目标**指令地址**：需要立即数位置时在真实地址上单条反汇编取 `encoding.imm_offset`，不新增立即数地址符号，也不按 `patch_sig` 重新定位。
 - 上游契约升级（2026-09-08，schema 7 / dataset schema 4）：每个 module/platform 增加必需布尔 `isBlob`（仅通过完整 Metahook blob 解密/重建/校验的 Windows 二进制为 true；非 Windows 必须 false），并移除旧 `path`。MetaHook 只消费 `binaries.*.windows.crc64`，不读取 `isBlob`（遵循上文“信任上游”约定）。
+- 上游契约升级（2026-09-12，dataset schema 5 / source snapshot contract 8 / analysis output contract 3，issue #865 前置）：新增 `kind: scalar`（payload 仅 `scalar_name` + uint32 `scalar_value`）。`src/GameData.cpp` 常量切到 `kSnapshotSchemaVersion 5` / `kSnapshotContractVersion 8` / `kAnalysisOutputContractVersion 3`，新增 `NormalizeScalar` 与公共 `QueryGameSymbolScalar`（API 111）；不再接受 schema 4 / contract 7 数据（逐 snapshot 记为 `unsupported schemaVersion`）。`scripts/sync-gamedata.py` 的 `SUPPORTED_SNAPSHOT_SCHEMA_VERSION 5` / `SUPPORTED_SNAPSHOT_CONTRACT_VERSION 8` / `SUPPORTED_ANALYSIS_OUTPUT_CONTRACT_VERSION 3`、`scripts/validate-gamedata.py` 的 `REQUIRED_SCALARS`（`size_of_frame` 属于 engine module，10 个受支持 engine 版本均覆盖）与 `isBlob` 布尔校验同步升级；行为测试见 `scripts/tests/test_gamedata_contract.py`。`gv_sig_allow_across_function_boundary` 现已在 `NormalizeGlobal` 中解析进 `flags`。`mh_gamesymbol_t` 布局与 `MetahookAPIVersion` 旧槽位不变；scalar 只经新槽位（第 8 个函数槽）获取，避免破坏旧插件 ABI。index 仍为 schema 4。
 - 发布数据状态（2026-09-09 同步，release `v20260909c` / source `ecac7773`）：`scripts/validate-gamedata.py` 门禁通过（16 snapshots / 5 engine families），cvar 分支、blob 客户端符号与 #855 的 6 个符号已补齐；门禁按 kind 校验的 `COMMON_REQUIRED` 现含 `cl_resourcesonhand` global 与 `R_StudioDrawPlayer` / `studioapi_SetupPlayerModel` / `Host_IsSinglePlayerGame` function、`DM_PlayerState` / `cl_players_model` / `engine` global，`NUMBERED_PATCH_SETS` 为 `Sys_InitMemory_HeapLimitPatches`、`S_LoadSound_to_FS_Open_callsite`、`Mod_LoadModel_to_FS_Open_callsite`（从 `_0` 起连续、kind 必须为 patch）；含 windows 记录的为 cof-5936（46）、hl-10210（80）、hl-8684（80）、hl-6153（43）、hl-4554/hl-3647/hl-3329/hl-3266/hl-3248（各 44）、svencoop-10257（75），cstrike/czero/czeror 各版本仍为 0 记录空壳。发布流程注意：`release-build.yml` 的 `publish-release` 曾在创建 tag 时返回 403 `Resource not accessible by integration`（run 34360429634，临时性；重跑 run 34363903670 后成功），发布未完成时 `hlnd2t.github.io` 的 index 不会更新，`sync-gamedata.py` 也就拉不到新数据。
 - `Build\svencoop\metahook\gamedata\` 被 gitignore，由 Pre-build 的 `sync-gamedata.py` 通过同卷 staging + 事务式目录交换生成；commit `6b8f6f65 "remove gamedata."` 删除了原先跟踪的 JSON 载荷。
 
@@ -108,6 +111,6 @@ flowchart TD
 
 - `src/metahook.cpp` — `MH_LoadEngine_ResolveSymbol`（`MH_ResolveGameSymbol` / `MH_GetModuleCRC64` / `MH_GetGameSymbolStatusString`）、`MH_LoadEngine_ResolveGlobalOperand`（`MH_QueryGameSymbol`）、`MH_LoadEngine_DetermineEngineType`（`MH_GetModuleCRC64` + `GameData::GetGameVersion`）、`MH_LoadEngine_PatchCvarCallbacks` / `MH_LoadEngine_FindLoadBlobClient`（`MH_IsGameSymbolAvailable`）、`MH_LoadEngine`（`GameData::Initialize` / `RegisterModuleFileSource` / `RegisterMirrorAlias` / `ResetModuleIdentities`）。
 - `src/LoadDllNotification.cpp` — 加/卸载通知中 `GameData::InvalidateModule(ctx.ImageBase, inCritRegion)`。
-- V3/V4 插件 — 通过 `metahook_api_t` API 109 的 6 个函数槽调用；API 110 起可用 `IsGameSymbolAvailable`（第 7 槽）。
+- V3/V4 插件 — 通过 `metahook_api_t` API 109 的 6 个函数槽调用；API 110 起可用 `IsGameSymbolAvailable`（第 7 槽）；API 111 起可用 `QueryGameSymbolScalar`（第 8 槽）。
 
 Related: [[metahook-privatevars]] [[project-overview]] [[plugin-system]]

--- a/scripts/sync-gamedata.py
+++ b/scripts/sync-gamedata.py
@@ -27,8 +27,9 @@ DEFAULT_INDEX_URL = (
 INDEX_URL_ENVIRONMENT_VARIABLE = "GOLDSRC_VIBESIGNATURES_INDEX_URL"
 INDEX_FILE_NAME = "index.json"
 SUPPORTED_INDEX_SCHEMA_VERSION = 4
-SUPPORTED_SNAPSHOT_SCHEMA_VERSION = 4
-SUPPORTED_SNAPSHOT_CONTRACT_VERSION = 7
+SUPPORTED_SNAPSHOT_SCHEMA_VERSION = 5
+SUPPORTED_SNAPSHOT_CONTRACT_VERSION = 8
+SUPPORTED_ANALYSIS_OUTPUT_CONTRACT_VERSION = 3
 MAXIMUM_INDEX_BYTES = 1024 * 1024
 MAXIMUM_SNAPSHOT_BYTES = 16 * 1024 * 1024
 MAXIMUM_VERSIONS = 4096
@@ -403,12 +404,19 @@ def validate_snapshot_contents(contents: bytes, entry: SnapshotEntry) -> None:
         "{} source".format(description),
         0xFFFFFFFF,
     )
-    require_uint(
+    analysis_output_contract_version = require_uint(
         source,
         "analysisOutputContractVersion",
         "{} source".format(description),
         0xFFFFFFFF,
     )
+    if analysis_output_contract_version != SUPPORTED_ANALYSIS_OUTPUT_CONTRACT_VERSION:
+        raise UpdateError(
+            "{} uses unsupported analysis output contract {}".format(
+                description,
+                analysis_output_contract_version,
+            )
+        )
     config_sha256 = require_string(
         source,
         "configSha256",

--- a/scripts/tests/test_gamedata_contract.py
+++ b/scripts/tests/test_gamedata_contract.py
@@ -1,0 +1,239 @@
+import hashlib
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+SCRIPTS = Path(__file__).parents[1]
+
+
+def load_module(name, filename):
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS / filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+validate = load_module("validate_gamedata", "validate-gamedata.py")
+sync = load_module("sync_gamedata", "sync-gamedata.py")
+
+SHA256_A = "a" * 64
+SHA256_CONFIG = "sha256:" + "b" * 64
+
+
+def make_snapshot(records=None, schema=5, contract=8, analysis=3, is_blob=True,
+                  game_version="hl-8684"):
+    records = records if records is not None else []
+    return {
+        "schemaVersion": schema,
+        "source": {
+            "gameVersion": game_version,
+            "snapshotSchemaVersion": contract,
+            "configDigestVersion": 2,
+            "analysisOutputContractVersion": analysis,
+            "configSha256": SHA256_CONFIG,
+            "fileCount": len(records),
+            "lastPublishTime": "2026-09-12T04:28:50Z",
+        },
+        "binaries": {
+            "engine": {
+                "windows": {
+                    "crc64": "0011223344556677",
+                    "size": 2123776,
+                    "sha256": SHA256_A,
+                    "isBlob": is_blob,
+                }
+            }
+        },
+        "records": records,
+    }
+
+
+def function_record(name="R_NewMap"):
+    return {
+        "platform": "windows",
+        "module": "engine",
+        "symbolName": name,
+        "kind": "function",
+        "payload": {
+            "func_rva": "0x1000",
+            "func_size": "0x10",
+            "func_sig": "55 8B EC",
+        },
+    }
+
+
+def scalar_record(name="size_of_frame", value=17080, module="engine",
+                  payload_name=None, payload_value=None):
+    return {
+        "platform": "windows",
+        "module": module,
+        "symbolName": name,
+        "kind": "scalar",
+        "payload": {
+            "scalar_name": name if payload_name is None else payload_name,
+            "scalar_value": value if payload_value is None else payload_value,
+        },
+    }
+
+
+class SnapshotContractTests(unittest.TestCase):
+    def test_accepts_new_scalar_contract(self):
+        doc = make_snapshot([function_record(), scalar_record()])
+        errors, module_crc64, symbols = validate.validate_snapshot(doc, "hl-8684")
+        self.assertEqual([], errors, errors)
+        self.assertEqual({"engine": 0x0011223344556677}, module_crc64)
+        self.assertEqual({"kind": "scalar", "value": 17080, "module": "engine"},
+                         symbols["size_of_frame"])
+
+    def test_rejects_legacy_snapshot_schema(self):
+        doc = make_snapshot(schema=4)
+        errors, _, _ = validate.validate_snapshot(doc, "hl-8684")
+        self.assertTrue(any("schemaVersion must be 5" in e for e in errors), errors)
+
+    def test_rejects_legacy_source_contract(self):
+        doc = make_snapshot(contract=7)
+        errors, _, _ = validate.validate_snapshot(doc, "hl-8684")
+        self.assertTrue(any("snapshotSchemaVersion must be 8" in e for e in errors), errors)
+
+    def test_rejects_legacy_analysis_output_contract(self):
+        doc = make_snapshot(analysis=2)
+        errors, _, _ = validate.validate_snapshot(doc, "hl-8684")
+        self.assertTrue(any("analysisOutputContractVersion must be 3" in e for e in errors), errors)
+
+    def test_requires_is_blob_boolean(self):
+        doc = make_snapshot([function_record()], is_blob="false")
+        errors, _, _ = validate.validate_snapshot(doc, "hl-8684")
+        self.assertTrue(any("isBlob must be a boolean" in e for e in errors), errors)
+
+    def test_rejects_invalid_scalar_value(self):
+        for bad in (-1, 0x100000000, "17080", True):
+            doc = make_snapshot([scalar_record(payload_value=bad)])
+            errors, _, _ = validate.validate_snapshot(doc, "hl-8684")
+            self.assertTrue(
+                any("invalid uint32 scalar_value" in e for e in errors),
+                (bad, errors),
+            )
+
+    def test_rejects_missing_scalar_name(self):
+        doc = make_snapshot([scalar_record(payload_name="")])
+        errors, _, _ = validate.validate_snapshot(doc, "hl-8684")
+        self.assertTrue(any("missing/invalid scalar_name" in e for e in errors), errors)
+
+
+class RequiredScalarGateTests(unittest.TestCase):
+    def complete_symbols(self):
+        symbols = {}
+        for name, kind in validate.COMMON_REQUIRED.items():
+            symbols[name] = {"kind": kind}
+        for prefix in validate.NUMBERED_PATCH_SETS:
+            symbols[f"{prefix}_0"] = {"kind": "patch"}
+        symbols["cvar_hooks"] = {"kind": "global"}
+        for name in ("NLoadBlob", "FreeBlob"):
+            symbols[name] = {"kind": "function"}
+        symbols["size_of_frame"] = {"kind": "scalar", "value": 17080, "module": "engine"}
+        return symbols
+
+    def test_scalar_gate_passes_when_present(self):
+        self.assertEqual(
+            [],
+            validate.validate_required(self.complete_symbols(), "ENGINE_GOLDSRC", "hl-8684"),
+        )
+
+    def test_scalar_gate_flags_missing_scalar(self):
+        symbols = self.complete_symbols()
+        del symbols["size_of_frame"]
+        errors = validate.validate_required(symbols, "ENGINE_GOLDSRC", "hl-8684")
+        self.assertTrue(any("missing required scalar 'size_of_frame'" in e for e in errors), errors)
+
+    def test_scalar_gate_flags_wrong_kind(self):
+        symbols = self.complete_symbols()
+        symbols["size_of_frame"] = {"kind": "global"}
+        errors = validate.validate_required(symbols, "ENGINE_GOLDSRC", "hl-8684")
+        self.assertTrue(any("must be a scalar record" in e for e in errors), errors)
+
+    def test_scalar_gate_flags_wrong_module(self):
+        symbols = self.complete_symbols()
+        symbols["size_of_frame"] = {"kind": "scalar", "value": 17080, "module": "client"}
+        errors = validate.validate_required(symbols, "ENGINE_GOLDSRC", "hl-8684")
+        self.assertTrue(any("must belong to module 'engine'" in e for e in errors), errors)
+
+
+def make_sync_entry(contents, game_version="hl-8684", contract=8, file_count=0):
+    return sync.SnapshotEntry(
+        game_version=game_version,
+        file_name="{}.{}.json".format(game_version, "c" * 64),
+        sha256=hashlib.sha256(contents).hexdigest(),
+        size=len(contents),
+        snapshot_schema_version=contract,
+        file_count=file_count,
+        last_publish_time="2026-09-12T04:28:50Z",
+    )
+
+
+def encode_snapshot(schema=5, contract=8, analysis=3):
+    import json
+
+    doc = make_snapshot(schema=schema, contract=contract, analysis=analysis)
+    return json.dumps(doc).encode("utf-8")
+
+
+class SyncContractTests(unittest.TestCase):
+    def test_contract_constants_match_new_dataset(self):
+        self.assertEqual(5, sync.SUPPORTED_SNAPSHOT_SCHEMA_VERSION)
+        self.assertEqual(8, sync.SUPPORTED_SNAPSHOT_CONTRACT_VERSION)
+        self.assertEqual(3, sync.SUPPORTED_ANALYSIS_OUTPUT_CONTRACT_VERSION)
+
+    def test_accepts_new_snapshot_contract(self):
+        contents = encode_snapshot()
+        sync.validate_snapshot_contents(contents, make_sync_entry(contents))
+
+    def test_rejects_legacy_snapshot_schema(self):
+        contents = encode_snapshot(schema=4)
+        with self.assertRaises(sync.UpdateError):
+            sync.validate_snapshot_contents(contents, make_sync_entry(contents))
+
+    def test_rejects_legacy_analysis_output_contract(self):
+        contents = encode_snapshot(analysis=2)
+        with self.assertRaises(sync.UpdateError):
+            sync.validate_snapshot_contents(contents, make_sync_entry(contents))
+
+    def test_parse_index_accepts_contract_eight(self):
+        import json
+
+        index = {
+            "schemaVersion": 4,
+            "versions": [{
+                "gameVersion": "hl-8684",
+                "url": "hl-8684.{}.json".format("d" * 64),
+                "sha256": "d" * 64,
+                "size": 1024,
+                "snapshotSchemaVersion": 8,
+                "fileCount": 1,
+                "lastPublishTime": "2026-09-12T04:28:50Z",
+            }],
+        }
+        parsed = sync.parse_index(json.dumps(index).encode("utf-8"), "test index")
+        self.assertEqual(8, parsed.entries[0].snapshot_schema_version)
+
+    def test_parse_index_rejects_contract_seven(self):
+        import json
+
+        index = {
+            "schemaVersion": 4,
+            "versions": [{
+                "gameVersion": "hl-8684",
+                "url": "hl-8684.{}.json".format("d" * 64),
+                "sha256": "d" * 64,
+                "size": 1024,
+                "snapshotSchemaVersion": 7,
+                "fileCount": 1,
+                "lastPublishTime": "2026-09-12T04:28:50Z",
+            }],
+        }
+        with self.assertRaises(sync.UpdateError):
+            sync.parse_index(json.dumps(index).encode("utf-8"), "test index")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate-gamedata.py
+++ b/scripts/validate-gamedata.py
@@ -62,6 +62,12 @@ NUMBERED_PATCH_SETS = (
     "Mod_LoadModel_to_FS_Open_callsite",
 )
 
+# scalar -> owning module, required for every declared engine family. Scalars
+# are plain uint32 values consumed verbatim (no image base, no dereference).
+REQUIRED_SCALARS = {
+    "size_of_frame": "engine",
+}
+
 # gameVersion -> engine family. Only these gameVersions are declared supported.
 # hl-4554 belongs to ENGINE_GOLDSRC: its hw.dll is a plain PE (isBlob false) with
 # build number 4554 <= 9000, so the launcher's rule-based mapping reports
@@ -193,12 +199,15 @@ def validate_index(index):
 def validate_snapshot(doc, game_version):
     """Return (errors, module_crc64: dict[str, int], symbol_records: dict)."""
     errors = []
-    if doc.get("schemaVersion") != 4:
-        errors.append(f"'{game_version}': snapshot schemaVersion must be 4")
+    if doc.get("schemaVersion") != 5:
+        errors.append(f"'{game_version}': snapshot schemaVersion must be 5")
         return errors, {}, {}
     source = doc.get("source")
-    if not isinstance(source, dict) or source.get("snapshotSchemaVersion") != 7:
-        errors.append(f"'{game_version}': source.snapshotSchemaVersion must be 7")
+    if not isinstance(source, dict) or source.get("snapshotSchemaVersion") != 8:
+        errors.append(f"'{game_version}': source.snapshotSchemaVersion must be 8")
+        return errors, {}, {}
+    if source.get("analysisOutputContractVersion") != 3:
+        errors.append(f"'{game_version}': source.analysisOutputContractVersion must be 3")
         return errors, {}, {}
 
     binaries = doc.get("binaries")
@@ -222,6 +231,8 @@ def validate_snapshot(doc, game_version):
             errors.append(f"'{game_version}': module '{mod}': invalid size")
         if not is_lower_hex(sha, 64):
             errors.append(f"'{game_version}': module '{mod}': invalid sha256")
+        if not isinstance(win.get("isBlob"), bool):
+            errors.append(f"'{game_version}': module '{mod}': isBlob must be a boolean")
         if crc64 is not None:
             module_crc64[mod] = crc64
 
@@ -306,6 +317,21 @@ def validate_snapshot(doc, game_version):
             if name in symbols and symbols[name] != rec:
                 errors.append(f"'{game_version}': conflicting duplicate symbol '{name}'")
             symbols[name] = rec
+        elif kind == "scalar":
+            p = payload if isinstance(payload, dict) else {}
+            scalar_name = p.get("scalar_name")
+            scalar_value = p.get("scalar_value")
+            if not isinstance(scalar_name, str) or not scalar_name:
+                errors.append(f"'{game_version}': scalar '{name}' missing/invalid scalar_name")
+                continue
+            if (not isinstance(scalar_value, int) or isinstance(scalar_value, bool)
+                    or not 0 <= scalar_value <= 0xFFFFFFFF):
+                errors.append(f"'{game_version}': scalar '{name}' has an invalid uint32 scalar_value")
+                continue
+            rec = {"kind": "scalar", "value": scalar_value, "module": mod}
+            if name in symbols and symbols[name] != rec:
+                errors.append(f"'{game_version}': conflicting duplicate symbol '{name}'")
+            symbols[name] = rec
         else:
             # unsupported kind is tolerated by the catalog; skip.
             continue
@@ -335,6 +361,15 @@ def validate_required(symbols, family, game_version):
             if rec.get("kind") != "patch":
                 errors.append(f"'{game_version}' ({family}): '{name}' must be a patch record")
             index += 1
+
+    for sym, module in REQUIRED_SCALARS.items():
+        rec = symbols.get(sym)
+        if not isinstance(rec, dict):
+            errors.append(f"'{game_version}' ({family}): missing required scalar '{sym}'")
+        elif rec.get("kind") != "scalar":
+            errors.append(f"'{game_version}' ({family}): '{sym}' must be a scalar record")
+        elif rec.get("module") != module:
+            errors.append(f"'{game_version}' ({family}): '{sym}' must belong to module '{module}'")
 
     # cvar branch: the engine's native callback list, or at least one managed
     # Cvar_Set -> Cvar_DirectSet call-site redirect.

--- a/src/GameData.cpp
+++ b/src/GameData.cpp
@@ -31,8 +31,9 @@ namespace
 	// Gamedata contract versions emitted by the upstream dataset generator
 	// (gamesymbols_json.py); keep in sync with scripts/sync-gamedata.py.
 	constexpr int kIndexSchemaVersion = 4;
-	constexpr int kSnapshotSchemaVersion = 4;
-	constexpr int kSnapshotContractVersion = 7;
+	constexpr int kSnapshotSchemaVersion = 5;
+	constexpr int kSnapshotContractVersion = 8;
+	constexpr int kAnalysisOutputContractVersion = 3;
 
 	// -----------------------------------------------------------------------
 	// Internal record / module / catalog model (stable heap-owned storage).
@@ -54,6 +55,8 @@ namespace
 		DWORD instructionOffset = 0;
 		DWORD operandOffset = 0;
 		DWORD instructionLength = 0;
+
+		uint32_t scalarValue = 0;   // valid only when kind == MH_GAMESYMBOL_KIND_SCALAR
 
 		bool conflicted = false;   // duplicate key with differing content
 		bool unsupportedKind = false; // kind not typed by this API version
@@ -393,6 +396,11 @@ namespace
 		rec.operandOffset = instDisp;
 		rec.instructionLength = instLength;
 		rec.flags = 0;
+
+		const rapidjson::Value* allowAcross = FindMember(payload, "gv_sig_allow_across_function_boundary");
+		if (allowAcross && allowAcross->IsBool() && allowAcross->GetBool())
+			rec.flags |= MH_GAMESYMBOL_FLAG_SIGNATURE_ALLOW_ACROSS_FUNCTION_BOUNDARY;
+
 		return true;
 	}
 
@@ -421,6 +429,30 @@ namespace
 		rec.operandOffset = 0;
 		rec.instructionLength = 0;
 		rec.flags = 0;
+		return true;
+	}
+
+	// A scalar record carries a uint32 value instead of an address. The value is
+	// consumed verbatim: no image base, no dereference, no instruction extraction.
+	bool NormalizeScalar(const rapidjson::Value& payload, GameSymbolRecord& rec, std::string& error)
+	{
+		const rapidjson::Value* scalarName = FindMember(payload, "scalar_name");
+		const rapidjson::Value* scalarValue = FindMember(payload, "scalar_value");
+		if (!scalarName || !scalarName->IsString() || !scalarValue || !scalarValue->IsUint())
+		{
+			error = "scalar payload is missing scalar_name/scalar_value";
+			return false;
+		}
+
+		rec.kind = MH_GAMESYMBOL_KIND_SCALAR;
+		rec.rva = 0;
+		rec.symbolSize = 0;
+		rec.signatureRva = 0;
+		rec.instructionOffset = 0;
+		rec.operandOffset = 0;
+		rec.instructionLength = 0;
+		rec.flags = 0;
+		rec.scalarValue = scalarValue->GetUint();
 		return true;
 	}
 
@@ -462,6 +494,7 @@ namespace
 			a.instructionOffset == b.instructionOffset &&
 			a.operandOffset == b.operandOffset &&
 			a.instructionLength == b.instructionLength &&
+			a.scalarValue == b.scalarValue &&
 			a.unsupportedKind == b.unsupportedKind;
 	}
 
@@ -567,6 +600,12 @@ namespace
 		if (!sourceSchema || !sourceSchema->IsInt() || sourceSchema->GetInt() != kSnapshotContractVersion)
 		{
 			AddDiagnostic("snapshot '%s': unsupported source.snapshotSchemaVersion", gameVersion);
+			return;
+		}
+		const rapidjson::Value* analysisContract = FindMember(*source, "analysisOutputContractVersion");
+		if (!analysisContract || !analysisContract->IsInt() || analysisContract->GetInt() != kAnalysisOutputContractVersion)
+		{
+			AddDiagnostic("snapshot '%s': unsupported source.analysisOutputContractVersion", gameVersion);
 			return;
 		}
 
@@ -675,6 +714,16 @@ namespace
 				{
 					if (error.empty())
 						error = "patch payload must be an object";
+					AddDiagnostic("snapshot '%s': symbol '%s': %s", gameVersion, symbolName->GetString(), error.c_str());
+					continue;
+				}
+			}
+			else if (std::strcmp(kindStr, "scalar") == 0)
+			{
+				if (!payload || !payload->IsObject() || !NormalizeScalar(*payload, record, error))
+				{
+					if (error.empty())
+						error = "scalar payload must be an object";
 					AddDiagnostic("snapshot '%s': symbol '%s': %s", gameVersion, symbolName->GetString(), error.c_str());
 					continue;
 				}
@@ -1131,6 +1180,36 @@ namespace GameData
 		return MH_GAMESYMBOL_OK;
 	}
 
+	mh_gamesymbol_status_t QueryScalarByCRC64(uint64_t moduleCRC64, const char* symbolName, uint32_t* outValue)
+	{
+		if (!outValue || !symbolName || !*symbolName)
+			return MH_GAMESYMBOL_INVALID_ARGUMENT;
+		*outValue = 0;
+
+		if (!g_catalog.available)
+			return MH_GAMESYMBOL_GAMEDATA_UNAVAILABLE;
+
+		auto mit = g_catalog.modules.find(moduleCRC64);
+		if (mit == g_catalog.modules.end())
+			return MH_GAMESYMBOL_MODULE_NOT_FOUND;
+
+		ModuleCatalog& mc = *mit->second;
+		auto sit = mc.symbols.find(symbolName);
+		if (sit == mc.symbols.end())
+			return MH_GAMESYMBOL_SYMBOL_NOT_FOUND;
+
+		GameSymbolRecord& rec = *sit->second;
+		if (rec.conflicted)
+			return MH_GAMESYMBOL_CATALOG_CONFLICT;
+		if (rec.unsupportedKind)
+			return MH_GAMESYMBOL_UNSUPPORTED_KIND;
+		if (rec.kind != MH_GAMESYMBOL_KIND_SCALAR)
+			return MH_GAMESYMBOL_KIND_MISMATCH;
+
+		*outValue = rec.scalarValue;
+		return MH_GAMESYMBOL_OK;
+	}
+
 	bool GetGameVersion(uint64_t moduleCRC64, const char** outGameVersion)
 	{
 		if (!outGameVersion)
@@ -1295,6 +1374,24 @@ mh_gamesymbol_status_t MH_QueryGameSymbol(PVOID moduleBase, const char* symbolNa
 		return st;
 
 	return GameData::QueryByCRC64(crc64, symbolName, outSymbol);
+}
+
+mh_gamesymbol_status_t MH_QueryGameSymbolScalar(PVOID moduleBase, const char* symbolName, uint32_t* outValue)
+{
+	if (!outValue || !symbolName || !*symbolName)
+		return MH_GAMESYMBOL_INVALID_ARGUMENT;
+
+	*outValue = 0;
+
+	if (!moduleBase)
+		return MH_GAMESYMBOL_INVALID_ARGUMENT;
+
+	uint64_t crc64 = 0;
+	mh_gamesymbol_status_t st = GameData::GetModuleCRC64(moduleBase, &crc64);
+	if (st != MH_GAMESYMBOL_OK)
+		return st;
+
+	return GameData::QueryScalarByCRC64(crc64, symbolName, outValue);
 }
 
 mh_gamesymbol_status_t MH_ResolveGameSymbol(PVOID moduleBase, const char* symbolName, mh_gamesymbol_kind_t expectedKind, PVOID* outAddress)

--- a/src/GameData.h
+++ b/src/GameData.h
@@ -30,6 +30,10 @@ namespace GameData
 	// The caller must initialize outSymbol->cbSize to sizeof(mh_gamesymbol_t).
 	mh_gamesymbol_status_t QueryByCRC64(uint64_t moduleCRC64, const char* symbolName, mh_gamesymbol_t* outSymbol);
 
+	// Query a scalar (uint32) value by (moduleCRC64, symbolName). Returns
+	// MH_GAMESYMBOL_KIND_MISMATCH when the symbol exists with a non-scalar kind.
+	mh_gamesymbol_status_t QueryScalarByCRC64(uint64_t moduleCRC64, const char* symbolName, uint32_t* outValue);
+
 	// Look up the catalog gameVersion for a module CRC-64. Returns false and sets
 	// *outGameVersion to nullptr when outGameVersion is null, the catalog is
 	// unavailable, or the CRC-64 is not catalogued. The returned string is owned
@@ -63,6 +67,7 @@ namespace GameData
 mh_gamesymbol_status_t MH_GetModuleCRC64(PVOID moduleBase, uint64_t* outCRC64);
 mh_gamesymbol_status_t MH_QueryGameSymbol(PVOID moduleBase, const char* symbolName, mh_gamesymbol_t* outSymbol);
 mh_gamesymbol_status_t MH_QueryGameSymbolByCRC64(uint64_t moduleCRC64, const char* symbolName, mh_gamesymbol_t* outSymbol);
+mh_gamesymbol_status_t MH_QueryGameSymbolScalar(PVOID moduleBase, const char* symbolName, uint32_t* outValue);
 mh_gamesymbol_status_t MH_ResolveGameSymbol(PVOID moduleBase, const char* symbolName, mh_gamesymbol_kind_t expectedKind, PVOID* outAddress);
 mh_gamesymbol_status_t MH_IsGameSymbolAvailable(PVOID moduleBase, const char* symbolName);
 PVOID MH_SearchPatternMasked(PVOID searchBase, DWORD searchLength, const BYTE* patternBytes, const BYTE* patternMask, DWORD patternLength);

--- a/src/metahook.cpp
+++ b/src/metahook.cpp
@@ -4089,5 +4089,6 @@ metahook_api_t gMetaHookAPI =
 	MH_SearchPatternMasked,
 	MH_GetGameSymbolStatusString,
 	MH_IsGameSymbolAvailable,
+	MH_QueryGameSymbolScalar,
 	NULL
 };


### PR DESCRIPTION
## Summary

实现 issue #865 的「gamedata schema 与 scalar 前置升级」。上游发布已切到 **dataset schema 5 / source snapshot contract 8 / analysis output contract 3**，旧版 `sync-gamedata.py` 直接 `exit 1`（`remote index version entry 0 uses unsupported snapshot contract 8`），本 PR 解除该阻塞并打通 `size_of_frame` scalar 消费契约。

- **契约升级**：`src/GameData.cpp` 与 `scripts/sync-gamedata.py` 常量切到 dataset 5 / contract 8 / analysis 3；旧代际逐 snapshot 明确拒绝（diagnostic），不把旧地址型记录误解释为 scalar。
- **scalar 解析**：新增 `NormalizeScalar`，保留 uint32 `scalar_value`，地址字段全 0；`gv_sig_allow_across_function_boundary` 现解析进 `flags`。
- **类型明确的新 API**：`MH_GAMESYMBOL_KIND_SCALAR` + `QueryGameSymbolScalar`（API 111，追加到 `metahook_api_t` 末尾）。**不改动 `mh_gamesymbol_t` 布局**，避免 `cbSize` 门禁破坏旧插件 ABI；`ResolveGameSymbol` 继续拒绝 scalar（`expectedKind` 仅 FUNCTION/GLOBAL/PATCH）。
- **发布门禁**：`validate-gamedata.py` 增加 scalar 解析、`isBlob` 布尔校验、`REQUIRED_SCALARS`（`size_of_frame` 属 engine module）；`sync-gamedata.py` 增加 analysis output contract 校验。
- **测试**：`scripts/tests/test_gamedata_contract.py`（17 例）覆盖契约代际接受/拒绝、scalar 值边界、kind/module 门禁、index contract 8。
- **文档/记忆**：`docs/MetaHook.md` / `MetaHookCN.md` / `memory/GameData.md` 同步 API 111 与 scalar 语义。

范围严格限定为前置升级：不迁移 BulletPhysics 消费者，不新增游戏家族承诺，index 仍为 schema 4。

## Verification

- `python scripts/sync-gamedata.py --target-dir Build/svencoop/metahook/gamedata --temp-root ...` → exit 0（下载并发布 16 snapshots，解除 #865 中记录的 contract 8 阻塞）
- `python scripts/validate-gamedata.py Build/svencoop/metahook/gamedata` → exit 0（16 snapshots / 5 engine families，含 `size_of_frame` engine scalar）
- `python -m unittest discover -s scripts/tests` → 52 passed, 2 skipped（含新增 17 例）
- MetaHook `Release|Win32` 构建成功（0 warnings / 0 errors）
- HeapPatch / PrecacheManager / SCModelDownloader / ThreadGuard / ResourceReplacer / BulletPhysics `Release|Win32` 构建成功

未验证项：无 C++ 单元测试框架，`GameData.cpp` 的 scalar 运行时行为未做离线单测（无对应 harness）；也未做实机冒烟（本 PR 不含消费者，未新增 hook）。`gv_sig_allow_across_function_boundary` 解析为附加对齐，无消费者使用。

Refs #865